### PR TITLE
add word=>keyword to excludes fields

### DIFF
--- a/utils/apiFeatures.js
+++ b/utils/apiFeatures.js
@@ -6,7 +6,7 @@ class ApiFeatures {
 
   filter() {
     const queryStringObj = { ...this.queryString };
-    const excludesFields = ['page', 'sort', 'limit', 'fields'];
+    const excludesFields = ['page', 'sort', 'limit', 'fields', 'keyword'];
     excludesFields.forEach((field) => delete queryStringObj[field]);
     // Apply filtration using [gte, gt, lte, lt]
     let queryStr = JSON.stringify(queryStringObj);


### PR DESCRIPTION
add word=>keyword to excludes fields
the request not response data with this issue 
for ex ...
i need to create product 
and quey string i want to send it 
price[gte] = 200 and keyword = mens
the query string => 
in search  {$or : [{title: {$regex: 'mens' , $options: 'i'}  } , {description: {$regex: 'mens' , $options: 'i'}  }]  }
and filter { price: { "$gte" :  50 } , keyword: "mens"  } and this quey not match filter query

